### PR TITLE
Provide a way for a caller to check if models can be loaded

### DIFF
--- a/lib/discretion/helpers.rb
+++ b/lib/discretion/helpers.rb
@@ -8,8 +8,11 @@ module Discretion
       Rails.env.test?
     end
 
-    def can_see_records?(viewer, *records)
-      records.all? { |record| Discretion.can_see_record?(viewer, record) }
+    def try_to(viewer)
+      yield
+      true
+    rescue Discretion::CannotSeeError, Discretion::CannotWriteError
+      false
     end
 
     def omnisciently

--- a/spec/discretion_spec.rb
+++ b/spec/discretion_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe Discretion do
     end
 
     context 'viewing' do
+      context 'via helpers' do
+        it 'should work without throwing' do
+          staff1
+          Discretion.set_current_viewer(nil)
+          pretend_not_in_test
+          expect { staff1.reload }.to raise_error(Discretion::CannotSeeError)
+          expect(Discretion.try_to(nil) { staff1.reload }).to be false
+
+          expect { staff1.update!(name: 'foobar') }.to raise_error(Discretion::CannotWriteError)
+          expect(Discretion.try_to(nil) { staff1.update!(name: 'foobar') }).to be false
+        end
+      end
+
       context 'staff' do
         it 'should be allowed for staff himself' do
           Discretion.set_current_viewer(staff1)


### PR DESCRIPTION
The way to use this would be:

```ruby
can_viewer_see_donor = Discretion.try_to(viewer) { Donor.find_by(id: donor_id) }

can_viewer_see_donor = Discretion.try_to(viewer) { donor }
```