### PR TITLE
Introduce can_destroy? and check Discretion before allowing destructi…

### DIFF
--- a/lib/discretion/can.rb
+++ b/lib/discretion/can.rb
@@ -24,5 +24,17 @@ module Discretion
     def current_viewer_can_write_record?(record, changes, new_record)
       can_write_record?(Discretion.current_viewer, record, changes, new_record)
     end
+
+    def can_destroy_record?(viewer, record)
+      return true unless record.is_a?(Discretion::DiscreetModel)
+      return true if Discretion.currently_acting_as?(Discretion::OMNIPOTENT_VIEWER)
+
+      record.respond_to?(:can_destroy?, true) ?
+        record.send(:can_destroy?, viewer) : can_write_record?(viewer, record, {}, false)
+    end
+
+    def current_viewer_can_destroy_record?(record)
+      can_destroy_record?(Discretion.current_viewer, record)
+    end
   end
 end

--- a/lib/discretion/discreet_model.rb
+++ b/lib/discretion/discreet_model.rb
@@ -14,6 +14,12 @@ module Discretion
           raise Discretion::CannotWriteError
         end
       end
+
+      before_destroy ->(record) {
+        unless Discretion.current_viewer_can_destroy_record?(record)
+          raise Discretion::CannotDestroyError
+        end
+      }, prepend: true
     end
   end
 end

--- a/lib/discretion/errors.rb
+++ b/lib/discretion/errors.rb
@@ -1,4 +1,5 @@
 module Discretion
   class CannotSeeError < StandardError; end
   class CannotWriteError < StandardError; end
+  class CannotDestroyError < StandardError; end
 end

--- a/spec/discretion_spec.rb
+++ b/spec/discretion_spec.rb
@@ -207,6 +207,121 @@ RSpec.describe Discretion do
       end
     end
 
+    context 'destroying' do
+      context 'donations' do
+        it 'should be allowed in test' do
+          Discretion.set_current_viewer(nil)
+          donation1
+          donation1.destroy!
+          expect(donation1.destroyed?).to be true
+        end
+
+        it 'should not be allowed when not in test' do
+          Discretion.set_current_viewer(nil)
+          donation1
+          pretend_not_in_test
+          expect { donation1.destroy! }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        context 'omnisciently' do
+          it 'should not be allowed' do
+            Discretion.set_current_viewer(nil)
+            donation1
+            pretend_not_in_test
+            expect {
+              Discretion.omnisciently do
+                donation1.destroy!
+              end
+            }.to raise_error(Discretion::CannotDestroyError)
+          end
+        end
+
+        context 'omnipotently' do
+          it 'should be allowed' do
+            Discretion.set_current_viewer(nil)
+            donation1
+            pretend_not_in_test
+            Discretion.omnipotently do
+              donation1.destroy!
+              expect(donation1.destroyed?).to be true
+            end
+          end
+        end
+      end
+
+      context 'staff' do
+        it 'should be allowed in test' do
+          Discretion.set_current_viewer(nil)
+          staff1
+          staff1.destroy!
+          expect(staff1.destroyed?).to be true
+        end
+
+        it 'should not be allowed without a viewer' do
+          Discretion.set_current_viewer(nil)
+          staff1
+          pretend_not_in_test
+          expect { staff1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should not be allowed by the staff themselves' do
+          Discretion.set_current_viewer(staff1)
+          pretend_not_in_test
+          expect { staff1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should not be allowed by other staff' do
+          Discretion.set_current_viewer(staff2)
+          staff1
+          pretend_not_in_test
+          expect { staff1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should not be allowed by donors' do
+          Discretion.set_current_viewer(donor1)
+          staff1
+          pretend_not_in_test
+          expect { staff1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+      end
+
+      context 'donors' do
+        it 'should be allowed in test' do
+          Discretion.set_current_viewer(nil)
+          donor1
+          donor1.destroy!
+          expect(donor1.destroyed?).to be true
+        end
+
+        it 'should not be allowed without a viewer' do
+          Discretion.set_current_viewer(nil)
+          donor1
+          pretend_not_in_test
+          expect { donor1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should not be allowed by a staff' do
+          Discretion.set_current_viewer(staff1)
+          pretend_not_in_test
+          donor1
+          expect { donor1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should not be allowed by another donor' do
+          Discretion.set_current_viewer(donor2)
+          donor1
+          pretend_not_in_test
+          expect { donor1.destroy }.to raise_error(Discretion::CannotDestroyError)
+        end
+
+        it 'should be allowed by the donor themselves' do
+          Discretion.set_current_viewer(donor1)
+          donor1.destroy!
+          expect(donor1.destroyed?).to be true
+        end
+      end
+    end
+
     context 'editing' do
       context 'donations' do
         it 'should be allowed if donor is editing the donor_note' do


### PR DESCRIPTION
…on of a record

If not defined explicitly, we will rely on `can_write?(viewer, record, {} /* changes */, false /* new_record */)`