### PR TITLE
Per-attribute privacy

### DIFF
--- a/lib/discretion/discreet_model.rb
+++ b/lib/discretion/discreet_model.rb
@@ -21,5 +21,24 @@ module Discretion
         end
       }, prepend: true
     end
+
+    class_methods do
+      def discreetly_read(attribute)
+        attribute = attribute.to_sym
+
+        define_method(attribute) {
+          can_read_attr = if Discretion.currently_acting_as?(Discretion::OMNISCIENT_VIEWER) ||
+                             Discretion.currently_acting_as?(Discretion::OMNIPOTENT_VIEWER)
+                            true
+                          else
+                            yield(Discretion.current_viewer, self)
+                          end
+
+          raise Discretion::CannotSeeError unless can_read_attr
+
+          read_attribute(attribute)
+        }
+      end
+    end
   end
 end

--- a/lib/discretion/version.rb
+++ b/lib/discretion/version.rb
@@ -1,3 +1,3 @@
 module Discretion
-  VERSION = '3.0.0.pre.alpha'.freeze
+  VERSION = '4.0.0.alpha'.freeze
 end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -11,6 +11,11 @@ class Staff < ApplicationRecord
 
   use_discretion
 
+  # Only logged-in Staff can see Staff emails.
+  discreetly_read(:email) do |viewer, _record|
+    viewer.is_a?(Staff)
+  end
+
   private
 
   def can_see?(viewer)
@@ -41,12 +46,18 @@ class Donor < ApplicationRecord
 
   use_discretion
 
+  # Only logged-in Donors can see their own emails.
+  discreetly_read(:email) do |viewer, record|
+    viewer == record
+  end
+
   private
 
   def can_see?(viewer)
     return true if Discretion.in_test?
 
     # Only the Donor herself or Staff of the organization can see the Donor.
+
     viewer.is_a?(Staff) || viewer&.id == id
   end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -6,12 +6,14 @@ ActiveRecord::Schema.define do
 
   create_table :staff, force: true do |t|
     t.string :name, null: false
+    t.string :email, null: false
     t.boolean :is_admin, null: false, default: false
     t.timestamps null: false
   end
 
   create_table :donors, force: true do |t|
     t.string :name, null: false
+    t.string :email, null: false
     t.timestamps null: false
   end
 


### PR DESCRIPTION
Introducing more granularity with respect to attribute access on records.

If an AR is already successfully loaded (i.e. passed `can_see?(viewer)` check), we may want to
even further restrict access on a per-attribute level. An example is wanting to restrict
the `email` attribute of a `User` to all but that `User` themself (sic). That is, if another
`User` is logged in, we may never want to show the email of some other `User` to them, or we
may only want to show emails of a subset of `User`s (e.g. friends of the logged-in user).

Added specs to test this, and bumped version to 4.0.0.alpha (note not `pre` anymore).